### PR TITLE
Add Option to Return Individual Attention Matrices

### DIFF
--- a/nystrom_attention/nystrom_attention.py
+++ b/nystrom_attention/nystrom_attention.py
@@ -64,7 +64,7 @@ class NystromAttention(nn.Module):
             padding = residual_conv_kernel // 2
             self.res_conv = nn.Conv2d(heads, heads, (kernel_size, 1), padding = (padding, 0), groups = heads, bias = False)
 
-    def forward(self, x, mask = None, return_attn = False):
+    def forward(self, x, mask = None, return_attn = False, return_attn_matrices = False):
         b, n, _, h, m, iters, eps = *x.shape, self.heads, self.num_landmarks, self.pinv_iterations, self.eps
 
         # pad so that sequence can be evenly divided into m landmarks
@@ -143,7 +143,9 @@ class NystromAttention(nn.Module):
         out = self.to_out(out)
         out = out[:, -n:]
 
-        if return_attn:
+        if return_attn_matrices:
+            return out, (attn1, attn2_inv, attn3)
+        elif return_attn:
             attn = attn1 @ attn2_inv @ attn3
             return out, attn
 


### PR DESCRIPTION
# Add option to return individual attention matrices

## Problem

I've been working with the Nystromformer on some longer sequences and ran into a memory issue. Currently, when we want to inspect the attention patterns using `return_attn=True`, the code computes the full attention matrix (`attn1 @ attn2_inv @ attn3`). For long sequences, this matrix becomes enormous and can quickly exceed available GPU memory!

## Solution

I'm proposing a simple enhancement that adds a new `return_attn_matrices` parameter to the `forward` method. When enabled, it returns the individual attention components (`attn1`, `attn2_inv`, `attn3`) instead of their combined product.

This small change has been super helpful in my work because:
- It's much more memory-friendly (no need to materialize the full attention matrix)
- It gives me more flexibility to analyze the different components separately
- It doesn't break any existing code - all the current functionality works exactly the same

### Usage Example

```python
# The original way still works perfectly:
output = model(x)
# or
output, attention = model(x, return_attn=True)

# And now we can also do:
output, (attn1, attn2_inv, attn3) = model(x, return_attn_matrices=True)
```

I hope this helps others who are working with longer sequences! I'd appreciate any feedback on this approach or suggestions for improvement.